### PR TITLE
Skip TLS with the metrics API server

### DIFF
--- a/kubernetes/helm-chart-apps/metrics-server/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 3.12.2
 helmChartURL: https://kubernetes-sigs.github.io/metrics-server/
 namespace: metrics-server
 syncWave: -99
-valuesRevision: deploy-metrics-server
+valuesRevision: HEAD

--- a/kubernetes/helm-chart-apps/metrics-server/values.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/values.yaml
@@ -1,0 +1,3 @@
+args:
+  # See https://github.com/kubernetes/kubeadm/issues/1223#issuecomment-549416594
+  - --kubelet-insecure-tls

--- a/kubernetes/helm-chart-apps/metrics-server/values.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/values.yaml
@@ -1,5 +1,0 @@
-defaultArgs:
-  - --cert-dir=/tmp
-  - --kubelet-preferred-address-types=Hostname,InternalIP,ExternalIP
-  - --kubelet-use-node-status-port
-  - --metric-resolution=15s

--- a/kubernetes/helm-chart-apps/metrics-server/values.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/values.yaml
@@ -1,0 +1,5 @@
+defaultArgs:
+  - --cert-dir=/tmp
+  - --kubelet-preferred-address-types=Hostname,InternalIP,ExternalIP
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s


### PR DESCRIPTION
- **Add TLS workaround because self-signed certs don't have IPs, even if it is preferred**
