### PR TITLE
Enable audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,30 @@ This is a laptop-only version of my [home lab](https://github.com/ginolatorilla/
 - Python 3
 - Terraform
 
-## Installation
+## Operations
+
+### Installation
 
 1. Change the variables in the inventory file at [ansible/inventory.yaml](./ansible/inventory.yaml).
-2. Run `./install.sh`. Call with `--check --diff` for a dry-run.
+2. Run `./install.sh`.
+
+### Dry run
+
+```sh
+./install.sh --check --dir
+```
+
+### Reset the cluster
+
+```sh
+./install.sh -e cluster_reset=1
+```
+
+### Update cluster resources
+
+```sh
+./install.sh --tags apps
+```
 
 ## Port forwarding
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a laptop-only version of my [home lab](https://github.com/ginolatorilla/
 ## Installation
 
 1. Change the variables in the inventory file at [ansible/inventory.yaml](./ansible/inventory.yaml).
-2. Run `./install.sh`.
+2. Run `./install.sh`. Call with `--check --diff` for a dry-run.
 
 ## Port forwarding
 

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -2,7 +2,7 @@ outputs_dir: "{{ (playbook_dir + '/../outputs') | realpath }}"
 
 virtual_machine:
   name: k8s
-  cpus: 10
+  cpus: 11
   memory: 48G
   disk: 40G
 

--- a/ansible/files/etc/kubernetes/audit-policy.yaml
+++ b/ansible/files/etc/kubernetes/audit-policy.yaml
@@ -1,0 +1,68 @@
+apiVersion: audit.k8s.io/v1 # This is required.
+kind: Policy
+# Don't generate audit events for all requests in RequestReceived stage.
+omitStages:
+  - "RequestReceived"
+rules:
+  # Log pod changes at RequestResponse level
+  - level: RequestResponse
+    resources:
+      - group: ""
+        # Resource "pods" doesn't match requests to any subresource of pods,
+        # which is consistent with the RBAC policy.
+        resources: ["pods"]
+  # Log "pods/log", "pods/status" at Metadata level
+  - level: Metadata
+    resources:
+      - group: ""
+        resources: ["pods/log", "pods/status"]
+
+  # Don't log requests to a configmap called "controller-leader"
+  - level: None
+    resources:
+      - group: ""
+        resources: ["configmaps"]
+        resourceNames: ["controller-leader"]
+
+  # Don't log watch requests by the "system:kube-proxy" on endpoints or services
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+      - group: "" # core API group
+        resources: ["endpoints", "services"]
+
+  # Don't log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated"]
+    nonResourceURLs:
+      - "/api*" # Wildcard matching.
+      - "/version"
+
+  # Log the request body of configmap changes in kube-system.
+  - level: Request
+    resources:
+      - group: "" # core API group
+        resources: ["configmaps"]
+    # This rule only applies to resources in the "kube-system" namespace.
+    # The empty string "" can be used to select non-namespaced resources.
+    namespaces: ["kube-system"]
+
+  # Log configmap and secret changes in all other namespaces at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core API group
+        resources: ["secrets", "configmaps"]
+
+  # Log all other resources in core and extensions at the Request level.
+  - level: Request
+    resources:
+      - group: "" # core API group
+      - group: "extensions" # Version of group should NOT be included.
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata
+    # Long-running requests like watches that fall under this rule will not
+    # generate an audit event in RequestReceived.
+    omitStages:
+      - "RequestReceived"

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -183,6 +183,13 @@
       notify:
         - reset cluster
 
+    - name: Trigger reset cluster
+      ansible.builtin.debug:
+        msg: "{{ 'Cluster reset triggered' if reset_cluster is defined and reset_cluster else 'Cluster reset not required' }}"
+      changed_when: reset_cluster is defined and reset_cluster
+      notify:
+        - reset cluster
+
     - name: Wait for handlers
       ansible.builtin.meta: flush_handlers
 

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -383,6 +383,19 @@
                   maxDuration: 3m
             revisionHistoryLimit: 0
 
+    - name: Wait for Vault pod to be started
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: vault-0
+            namespace: vault
+        wait: true
+        wait_condition:
+          type: PodReadyToStartContainers
+          status: "True"
+
     - name: Check Vault Status
       kubernetes.core.k8s_exec:
         namespace: vault
@@ -390,10 +403,10 @@
         container: vault
         command: vault status -tls-skip-verify
       register: vault_status
-      ignore_errors: true
+      retries: 3
       notify: unseal vault
       changed_when: vault_status.rc != 0
-      failed_when: vault_status.rc == 1 # 2 means vault is sealed sealed
+      failed_when: vault_status.rc == 1 # 2 means vault is sealed
 
     - name: Wait for handlers
       ansible.builtin.meta: flush_handlers

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -315,14 +315,6 @@
     - name: Wait for handlers
       ansible.builtin.meta: flush_handlers
 
-    - name: Untaint the node
-      kubernetes.core.k8s_taint:
-        state: absent
-        name: "{{ virtual_machine.name }}"
-        taints:
-          - key: node-role.kubernetes.io/control-plane
-            effect: NoSchedule
-
     - name: Deploy ArgoCD
       kubernetes.core.helm:
         name: argocd

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -188,7 +188,7 @@
 
     - name: Install single-node Kubernetes cluster with kubeadm
       ansible.builtin.command:
-        cmd: kubeadm init --config {{ kubeadm.dest }}
+        cmd: kubeadm init --config /etc/kubernetes/kubeadm.yaml
         creates: /etc/kubernetes/manifests/kube*.yaml
 
     - name: Get kubeconfig

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -443,6 +443,19 @@
             vault_unseal_keys: "{{ vault_operator_init.stdout | regex_findall('Unseal Key [0-9]+: ([a-zA-Z0-9+/=]+)') }}"
           listen: unseal vault
 
+        - name: Parse root token
+          set_fact:
+            vault_root_token: "{{ vault_operator_init.stdout | regex_findall('Initial Root Token: ([a-zA-Z0-9.+/=]+)') }}"
+          listen: unseal vault
+
+        - name: Save Vault root token to Terraform repo
+          ansible.builtin.copy:
+            content: |-
+              token="{{ vault_root_token[0] }}"
+            dest: "../terraform/vault/local.auto.tfvars"
+            mode: "0644"
+          listen: unseal vault
+
         - name: Unseal Vault
           kubernetes.core.k8s_exec:
             namespace: vault

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -402,6 +402,7 @@
         wait_condition:
           type: PodReadyToStartContainers
           status: "True"
+      retries: 10
 
     - name: Check Vault Status
       kubernetes.core.k8s_exec:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -158,6 +158,12 @@
         - kubelet
         - crio
 
+    - name: Configure Audit Policy
+      ansible.builtin.copy:
+        src: files/etc/kubernetes/audit-policy.yaml
+        dest: /etc/kubernetes/audit-policy.yaml
+        mode: "0644"
+
     - name: Configure kubeadm
       ansible.builtin.template:
         src: templates/etc/kubernetes/kubeadm.conf.j2

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -92,6 +92,16 @@
     - common_vars.yaml
   become: true
   tasks:
+    - name: Install own CA certificate
+      ansible.builtin.copy:
+        src: "{{ outputs_dir }}/certs/ownca.crt"
+        dest: /usr/local/share/ca-certificates/ownca.crt
+        mode: "0644"
+      notify: update ca-certificates
+
+    - name: Wait for handlers
+      ansible.builtin.meta: flush_handlers
+
     - name: Install required tools
       ansible.builtin.apt:
         update_cache: true
@@ -216,6 +226,11 @@
         mode: "0644"
 
   handlers:
+    - name: Update CA certificates
+      ansible.builtin.command: update-ca-certificates
+      when: ansible_os_family != 'Darwin'
+      listen: update ca-certificates
+
     - name: Load kernel modules
       ansible.builtin.command: "modprobe {{ item }}"
       loop:

--- a/ansible/templates/etc/kubernetes/kubeadm.conf.j2
+++ b/ansible/templates/etc/kubernetes/kubeadm.conf.j2
@@ -4,6 +4,7 @@ kind: InitConfiguration
 nodeRegistration:
   criSocket: unix:///var/run/crio/crio.sock
   imagePullPolicy: IfNotPresent
+  taints: []
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration

--- a/ansible/templates/etc/kubernetes/kubeadm.conf.j2
+++ b/ansible/templates/etc/kubernetes/kubeadm.conf.j2
@@ -12,6 +12,20 @@ apiServer:
   certSANs:
     - localhost
     - 127.0.0.1
+  extraArgs:
+    audit-policy-file: /etc/kubernetes/audit-policy.yaml
+    audit-log-path: /var/log/kubernetes/audit/audit.log
+  extraVolumes:
+    - hostPath: /etc/kubernetes/audit-policy.yaml
+      mountPath: /etc/kubernetes/audit-policy.yaml
+      name: audit-policy
+      pathType: File
+      readOnly: true
+    - hostPath: /mnt/data/kubernetes/audit
+      mountPath: /var/log/kubernetes/audit
+      name: audit-log
+      pathType: DirectoryOrCreate
+      readOnly: false
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ kubernetes_cluster_name }}
 controllerManager: {}

--- a/ansible/templates/lima.yaml.j2
+++ b/ansible/templates/lima.yaml.j2
@@ -35,3 +35,6 @@ provision:
   - # Remove the "lima-" prefix in the hostnames
     mode: system
     script: hostnamectl set-hostname {{ virtual_machine.name }}
+
+hostResolver:
+  enabled: false

--- a/terraform/vault/_config.tf
+++ b/terraform/vault/_config.tf
@@ -15,5 +15,9 @@ terraform {
 provider "vault" {
   address      = "https://vault.localhost"
   ca_cert_file = "../../outputs/certs/ownca.crt"
-  token        = regex("Token: (.+\\b)", file("../../outputs/vault_unseal_keys.txt"))[0]
+}
+
+variable "token" {
+  type      = string
+  sensitive = true
 }

--- a/terraform/vault/_config.tf
+++ b/terraform/vault/_config.tf
@@ -15,6 +15,7 @@ terraform {
 provider "vault" {
   address      = "https://vault.localhost"
   ca_cert_file = "../../outputs/certs/ownca.crt"
+  token        = var.token
 }
 
 variable "token" {


### PR DESCRIPTION
- Configure kube-apiserver to enable audit logs
- Install own CA in the node
- Drift correction for the VM config
- Ensure `--check` `--diff` works when running this playbook
- Remove taints at cluster configuration instead of in a later stage
- Make the installation of Vault reliable
