### PR TITLE
Private container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This is a laptop-only version of my [home lab](https://github.com/ginolatorilla/
 | Container networking version | 3.27.0                        |
 | Ingress controller           | Nginx                         |
 | Ingress controller version   | 3.4.3                         |
+| Private registry (cluster)   | registry:5001                 |
+| Private registry (host)      | localhost:5001                |
 
 ## Requirements
 
@@ -58,6 +60,7 @@ Lima automatically forwards the following localhost ports to the host:
 | 80   | HAProxy HTTP listener  |
 | 443  | HAProxy HTTPS listener |
 | 6443 | Kubernetes API         |
+| 5001 | Distribution registry  |
 
 ## Ingress
 

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -22,7 +22,7 @@ registry:
   docker_context: lima
   username: docker
   password: docker
-  port: 5000
+  port: 5001
   hosts:
     - registry
     - registry.local

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -27,5 +27,4 @@ registry:
   # username: docker
   # password: docker
   port: 5001
-  hosts:
-    - registry
+  hosts: []

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -28,5 +28,4 @@ registry:
   # password: docker
   port: 5001
   hosts:
-    - registry
     - registry.local

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -17,3 +17,8 @@ ingress_controller:
   node_ports:
     http: 30080
     https: 30443
+
+registry:
+  hosts:
+    - registry
+    - registry.local

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -2,10 +2,14 @@
 outputs_dir: "{{ (playbook_dir + '/../outputs') | realpath }}"
 
 virtual_machine:
-  name: k8s
-  cpus: 12
-  memory: 48G
-  disk: 40G
+  k8s:
+    cpus: 12
+    memory: 48G
+    disk: 40G
+  docker:
+    cpus: 4
+    memory: 8G
+    disk: 100G
 
 crio_version: "1.30"
 kubernetes_version: "1.30"

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -5,7 +5,7 @@ virtual_machine:
   k8s:
     cpus: 12
     memory: 48G
-    disk: 40G
+    disk: 200G
   docker:
     cpus: 4
     memory: 8G

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -24,8 +24,8 @@ ingress_controller:
 
 registry:
   docker_context: lima
-  username: docker
-  password: docker
+  # username: docker
+  # password: docker
   port: 5001
   hosts:
     - registry

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -19,6 +19,10 @@ ingress_controller:
     https: 30443
 
 registry:
+  docker_context: lima
+  username: docker
+  password: docker
+  port: 5000
   hosts:
     - registry
     - registry.local

--- a/ansible/common_vars.yaml
+++ b/ansible/common_vars.yaml
@@ -28,4 +28,4 @@ registry:
   # password: docker
   port: 5001
   hosts:
-    - registry.local
+    - registry

--- a/ansible/files/etc/crio/20-crio.conf
+++ b/ansible/files/etc/crio/20-crio.conf
@@ -1,0 +1,3 @@
+[crio.image]
+pause_image = "registry:5001/registry.k8s.io/pause:3.9"
+signature_policy = "/etc/crio/policy.json"

--- a/ansible/files/etc/kubernetes/manifests/haproxy.yaml
+++ b/ansible/files/etc/kubernetes/manifests/haproxy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-    - image: haproxy:2.1.4
+    - image: registry:5001/docker.io/haproxy:2.1.4
       name: haproxy
       volumeMounts:
         - mountPath: /usr/local/etc/haproxy/haproxy.cfg

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -306,10 +306,6 @@
         subject_alt_name: "{{ registry.hosts | map('regex_replace', '^', 'DNS:') | list }}"
       register: registry_csr
 
-    - name: debug
-      ansible.builtin.debug:
-        msg: "{{ registry_privatekey.keys() | list }}"
-
     - name: Create Registry TLS certificate
       community.crypto.x509_certificate:
         path: "{{ outputs_dir }}/certs/registry.crt"
@@ -319,6 +315,14 @@
         ownca_privatekey_path: "{{ ownca_privatekey.filename }}"
         provider: ownca
       register: registry_crt
+
+    - name: Setup basic auth for Registry
+      community.general.htpasswd:
+        path: "{{ outputs_dir }}/registry.htpasswd"
+        name: "{{ registry.username }}"
+        password: "{{ registry.password }}"
+        hash_scheme: bcrypt
+      register: registry_htpasswd
 
     - name: Modify /etc/hosts on Kubernetes node
       delegate_to: k8s
@@ -330,6 +334,40 @@
         regex: '([\da-fA-F:.]+)\s+host.lima.internal'
         line: '\1 host.lima.internal {{ registry.hosts | join(" ") }}'
         backrefs: true
+
+    - name: Stop existing Registry service
+      community.docker.docker_compose_v2:
+        cli_context: "{{ registry.docker_context }}"
+        project_name: registry
+        definition:
+          services:
+            registry:
+        state: absent
+        wait: true
+
+    - name: Launch the Registry Service
+      community.docker.docker_compose_v2:
+        cli_context: "{{ registry.docker_context }}"
+        project_name: registry
+        definition:
+          services:
+            registry:
+              restart: always
+              image: registry:2.8
+              ports:
+               - "{{ registry.port }}:443"
+              volumes:
+                - "{{ outputs_dir }}/registry:/var/lib/registry"
+                - "{{ outputs_dir }}/certs:/certs"
+                - "{{ outputs_dir }}/registry.htpasswd:/auth/htpasswd"
+              environment:
+                REGISTRY_HTTP_ADDR: "0.0.0.0:443"
+                REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
+                REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
+                REGISTRY_AUTH: "htpasswd"
+                REGISTRY_AUTH_HTPASSWD_REALM: "registry"
+                REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
+        wait: true
 
 - name: Deploy apps in Kubernetes
   tags: apps

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -304,12 +304,6 @@
         create_subject_key_identifier: true
         use_common_name_for_san: false
         subject_alt_name: "{{ registry.hosts | map('regex_replace', '^', 'DNS:') | list }}"
-        basic_constraints:
-          - "CA:TRUE"
-        basic_constraints_critical: true
-        key_usage:
-          - keyCertSign
-        key_usage_critical: true
       register: registry_csr
 
     - name: debug

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -211,6 +211,8 @@
         - registry.k8s.io/etcd:3.5.15-0
         - quay.io/argoproj/argocd:v2.13.0
         - public.ecr.aws/docker/library/redis:7.4.1-alpine
+        - quay.io/tigera/operator:v1.32.7
+        - docker.io/calico/ctl:v3.27.3
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0
@@ -452,6 +454,8 @@
         release_namespace: tigera-operator
         create_namespace: true
         wait: true
+        values_files:
+          - ../kubernetes/helm-chart-apps/tigera-operator/values.yaml
 
     - name: Wait for Calico to be ready
       kubernetes.core.k8s:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -213,6 +213,14 @@
         - public.ecr.aws/docker/library/redis:7.4.1-alpine
         - quay.io/tigera/operator:v1.32.7
         - docker.io/calico/ctl:v3.27.3
+        - docker.io/calico/apiserver:v3.27.3
+        - docker.io/calico/kube-controllers:v3.27.3
+        - docker.io/calico/node:v3.27.3
+        - docker.io/calico/cni:v3.27.3
+        - docker.io/calico/typha:v3.27.3
+        - docker.io/calico/csi:v3.27.3
+        - docker.io/calico/node-driver-registrar:v3.27.3
+        - docker.io/calico/pod2daemon-flexvol:v3.27.3
         - docker.io/haproxy:2.1.4
 
       register: skopeo_copy

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -326,6 +326,7 @@
       register: registry_crt
 
     - name: Setup basic auth for Registry
+      when: registry.username is defined and registry.password is defined
       community.general.htpasswd:
         path: "{{ outputs_dir }}/registry.htpasswd"
         name: "{{ registry.username }}"
@@ -361,6 +362,7 @@
         definition:
           services:
             registry:
+              container_name: registry
               restart: always
               image: registry:2.8
               ports:
@@ -373,7 +375,7 @@
                 REGISTRY_HTTP_ADDR: "0.0.0.0:443"
                 REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
                 REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
-                REGISTRY_AUTH: "htpasswd"
+                REGISTRY_AUTH: "{{ (registry.username is defined and registry.password is defined) | ternary('htpasswd', '') }}"
                 REGISTRY_AUTH_HTPASSWD_REALM: "registry"
                 REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
         wait: true

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -94,6 +94,97 @@
         removes: "~/lima/docker/*.pid"
       listen: restart vm docker
 
+- name: Container registry
+  tags: registry
+  hosts: localhost
+  vars_files:
+    - common_vars.yaml
+  tasks:
+    - name: Create signing key for Registry
+      community.crypto.openssl_privatekey:
+        path: "{{ outputs_dir }}/certs/registry.key"
+      register: registry_privatekey
+
+    - name: Create CSR for Registry
+      community.crypto.openssl_csr:
+        path: "{{ outputs_dir }}/certs/registry.csr"
+        privatekey_path: "{{ registry_privatekey.filename }}"
+        common_name: "My Container Registry"
+        create_subject_key_identifier: true
+        use_common_name_for_san: false
+        subject_alt_name: "{{ default_sans + (registry.hosts | map('regex_replace', '^', 'DNS:') | list) }}"
+      register: registry_csr
+      vars:
+        default_sans:
+          - DNS:registry
+          - DNS:host.lima.internal
+          - IP:192.168.5.2
+
+    - name: Create Registry TLS certificate
+      community.crypto.x509_certificate:
+        path: "{{ outputs_dir }}/certs/registry.crt"
+        privatekey_path: "{{ registry_privatekey.filename }}"
+        csr_path: "{{ registry_csr.filename }}"
+        ownca_path: "{{ ownca_crt.filename }}"
+        ownca_privatekey_path: "{{ ownca_privatekey.filename }}"
+        provider: ownca
+      register: registry_crt
+
+    - name: Setup basic auth for Registry
+      when: registry.username is defined and registry.password is defined
+      community.general.htpasswd:
+        path: "{{ outputs_dir }}/registry.htpasswd"
+        name: "{{ registry.username }}"
+        password: "{{ registry.password }}"
+        hash_scheme: bcrypt
+      register: registry_htpasswd
+
+    - name: Modify /etc/hosts on Kubernetes node
+      delegate_to: k8s
+      become: true
+      vars:
+        ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/k8s' + '/ssh.config' }}"
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        regex: '([\da-fA-F:.]+)\s+host.lima.internal'
+        line: '\1 host.lima.internal {{ registry.hosts | join(" ") }}'
+        backrefs: true
+
+    - name: Stop existing Registry service
+      community.docker.docker_compose_v2:
+        cli_context: "{{ registry.docker_context }}"
+        project_name: registry
+        definition:
+          services:
+            registry:
+        state: absent
+        wait: true
+
+    - name: Launch the Registry Service
+      community.docker.docker_compose_v2:
+        cli_context: "{{ registry.docker_context }}"
+        project_name: registry
+        definition:
+          services:
+            registry:
+              container_name: registry
+              restart: always
+              image: registry:2.8
+              ports:
+                - "{{ registry.port }}:443"
+              volumes:
+                - "{{ outputs_dir }}/registry:/var/lib/registry"
+                - "{{ outputs_dir }}/certs:/certs"
+                - "{{ outputs_dir }}/registry.htpasswd:/auth/htpasswd"
+              environment:
+                REGISTRY_HTTP_ADDR: "0.0.0.0:443"
+                REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
+                REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
+                # REGISTRY_AUTH: htpasswd
+                # REGISTRY_AUTH_HTPASSWD_REALM: "registry"
+                # REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
+        wait: true
+
 - name: Install Kubernetes
   tags: kubeadm
   hosts: k8s
@@ -293,97 +384,6 @@
         command: sh -c 'kill -HUP $(pidof haproxy)'
       ignore_errors: true
       listen: reload haproxy
-
-- name: Container registry
-  tags: registry
-  hosts: localhost
-  vars_files:
-    - common_vars.yaml
-  tasks:
-    - name: Create signing key for Registry
-      community.crypto.openssl_privatekey:
-        path: "{{ outputs_dir }}/certs/registry.key"
-      register: registry_privatekey
-
-    - name: Create CSR for Registry
-      community.crypto.openssl_csr:
-        path: "{{ outputs_dir }}/certs/registry.csr"
-        privatekey_path: "{{ registry_privatekey.filename }}"
-        common_name: "My Container Registry"
-        create_subject_key_identifier: true
-        use_common_name_for_san: false
-        subject_alt_name: "{{ default_sans + (registry.hosts | map('regex_replace', '^', 'DNS:') | list) }}"
-      register: registry_csr
-      vars:
-        default_sans:
-          - DNS:registry
-          - DNS:host.lima.internal
-          - IP:192.168.5.2
-
-    - name: Create Registry TLS certificate
-      community.crypto.x509_certificate:
-        path: "{{ outputs_dir }}/certs/registry.crt"
-        privatekey_path: "{{ registry_privatekey.filename }}"
-        csr_path: "{{ registry_csr.filename }}"
-        ownca_path: "{{ ownca_crt.filename }}"
-        ownca_privatekey_path: "{{ ownca_privatekey.filename }}"
-        provider: ownca
-      register: registry_crt
-
-    - name: Setup basic auth for Registry
-      when: registry.username is defined and registry.password is defined
-      community.general.htpasswd:
-        path: "{{ outputs_dir }}/registry.htpasswd"
-        name: "{{ registry.username }}"
-        password: "{{ registry.password }}"
-        hash_scheme: bcrypt
-      register: registry_htpasswd
-
-    - name: Modify /etc/hosts on Kubernetes node
-      delegate_to: k8s
-      become: true
-      vars:
-        ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/k8s' + '/ssh.config' }}"
-      ansible.builtin.lineinfile:
-        path: /etc/hosts
-        regex: '([\da-fA-F:.]+)\s+host.lima.internal'
-        line: '\1 host.lima.internal {{ registry.hosts | join(" ") }}'
-        backrefs: true
-
-    - name: Stop existing Registry service
-      community.docker.docker_compose_v2:
-        cli_context: "{{ registry.docker_context }}"
-        project_name: registry
-        definition:
-          services:
-            registry:
-        state: absent
-        wait: true
-
-    - name: Launch the Registry Service
-      community.docker.docker_compose_v2:
-        cli_context: "{{ registry.docker_context }}"
-        project_name: registry
-        definition:
-          services:
-            registry:
-              container_name: registry
-              restart: always
-              image: registry:2.8
-              ports:
-                - "{{ registry.port }}:443"
-              volumes:
-                - "{{ outputs_dir }}/registry:/var/lib/registry"
-                - "{{ outputs_dir }}/certs:/certs"
-                - "{{ outputs_dir }}/registry.htpasswd:/auth/htpasswd"
-              environment:
-                REGISTRY_HTTP_ADDR: "0.0.0.0:443"
-                REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
-                REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
-                # REGISTRY_AUTH: htpasswd
-                # REGISTRY_AUTH_HTPASSWD_REALM: "registry"
-                # REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
-        wait: true
 
 - name: Deploy apps in Kubernetes
   tags: apps

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -98,7 +98,7 @@
   tags: kubeadm
   hosts: k8s
   vars:
-    ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/' + virtual_machine.name + '/ssh.config' }}"
+    ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/k8s' + '/ssh.config' }}"
   vars_files:
     - common_vars.yaml
   become: true
@@ -289,7 +289,7 @@
       become: false
       kubernetes.core.k8s_exec:
         namespace: kube-system
-        pod: haproxy-{{ virtual_machine.name }}
+        pod: haproxy-k8s
         command: sh -c 'kill -HUP $(pidof haproxy)'
       ignore_errors: true
       listen: reload haproxy
@@ -337,7 +337,7 @@
       delegate_to: k8s
       become: true
       vars:
-        ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/' + virtual_machine.name + '/ssh.config' }}"
+        ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/k8s' + '/ssh.config' }}"
       ansible.builtin.lineinfile:
         path: /etc/hosts
         regex: '([\da-fA-F:.]+)\s+host.lima.internal'

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -120,7 +120,9 @@
         default_sans:
           - DNS:registry
           - DNS:host.lima.internal
+          - DNS:localhost
           - IP:192.168.5.2
+          - IP:127.0.0.1
 
     - name: Create Registry TLS certificate
       community.crypto.x509_certificate:
@@ -186,6 +188,21 @@
                 # REGISTRY_AUTH_HTPASSWD_REALM: "registry"
                 # REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
         wait: true
+
+    - name: Push Images
+      ansible.builtin.command: >-
+        skopeo --override-os linux
+        copy --dest-tls-verify=false
+        docker://{{ item }}
+        docker://localhost:{{ registry.port }}/{{ item }}
+      loop:
+        - registry.k8s.io/kube-apiserver:v1.30.12
+        - registry.k8s.io/kube-controller-manager:v1.30.12
+        - registry.k8s.io/kube-scheduler:v1.30.12
+        - registry.k8s.io/kube-proxy:v1.30.12
+        - registry.k8s.io/coredns/coredns:v1.11.3
+        - registry.k8s.io/pause:3.9
+        - registry.k8s.io/etcd:3.5.15-0
 
 - name: Install Kubernetes
   tags: kubeadm

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -209,6 +209,9 @@
         - registry.k8s.io/coredns/coredns:v1.11.3
         - registry.k8s.io/pause:3.9
         - registry.k8s.io/etcd:3.5.15-0
+        - quay.io/argoproj/argocd:v2.13.0
+        - public.ecr.aws/docker/library/redis:7.4.1-alpine
+
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0
 

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,5 +1,7 @@
 - name: Preparations
-  tags: prepare
+  tags:
+    - prepare
+    - registry
   hosts: localhost
   vars_files:
     - common_vars.yaml
@@ -282,6 +284,47 @@
         command: sh -c 'kill -HUP $(pidof haproxy)'
       ignore_errors: true
       listen: reload haproxy
+
+- name: Container registry
+  tags: registry
+  hosts: localhost
+  vars_files:
+    - common_vars.yaml
+  tasks:
+    - name: Create signing key for Registry
+      community.crypto.openssl_privatekey:
+        path: "{{ outputs_dir }}/certs/registry.key"
+      register: registry_privatekey
+
+    - name: Create CSR for Registry
+      community.crypto.openssl_csr:
+        path: "{{ outputs_dir }}/certs/registry.csr"
+        privatekey_path: "{{ registry_privatekey.filename }}"
+        common_name: "My Container Registry"
+        create_subject_key_identifier: true
+        use_common_name_for_san: false
+        subject_alt_name: "{{ registry.hosts | map('regex_replace', '^', 'DNS:') | list }}"
+        basic_constraints:
+          - "CA:TRUE"
+        basic_constraints_critical: true
+        key_usage:
+          - keyCertSign
+        key_usage_critical: true
+      register: registry_csr
+
+    - name: debug
+      ansible.builtin.debug:
+        msg: "{{ registry_privatekey.keys() | list }}"
+
+    - name: Create Registry TLS certificate
+      community.crypto.x509_certificate:
+        path: "{{ outputs_dir }}/certs/registry.crt"
+        privatekey_path: "{{ registry_privatekey.filename }}"
+        csr_path: "{{ registry_csr.filename }}"
+        ownca_path: "{{ ownca_crt.filename }}"
+        ownca_privatekey_path: "{{ ownca_privatekey.filename }}"
+        provider: ownca
+      register: registry_crt
 
 - name: Deploy apps in Kubernetes
   tags: apps

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -312,8 +312,13 @@
         common_name: "My Container Registry"
         create_subject_key_identifier: true
         use_common_name_for_san: false
-        subject_alt_name: "{{ registry.hosts | map('regex_replace', '^', 'DNS:') | list }}"
+        subject_alt_name: "{{ default_sans + (registry.hosts | map('regex_replace', '^', 'DNS:') | list) }}"
       register: registry_csr
+      vars:
+        default_sans:
+          - DNS:registry
+          - DNS:host.lima.internal
+          - IP:192.168.5.2
 
     - name: Create Registry TLS certificate
       community.crypto.x509_certificate:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -12,6 +12,8 @@
           - kubernetes-cli
           - helm
           - lima
+          - docker
+          - skopeo
       become: "{{ ansible_os_family != 'Darwin' }}"
 
     - name: Create certificate outputs directory

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -209,6 +209,8 @@
         - registry.k8s.io/coredns/coredns:v1.11.3
         - registry.k8s.io/pause:3.9
         - registry.k8s.io/etcd:3.5.15-0
+      register: skopeo_copy
+      changed_when: skopeo_copy.rc != 0
 
 - name: Install Kubernetes
   tags: kubeadm
@@ -284,6 +286,16 @@
           - kubeadm
           - kubectl
           - cri-o
+
+    - name: Configure CRIO
+      ansible.builtin.copy:
+        src: files/etc/crio/20-crio.conf
+        dest: /etc/crio/crio.conf.d/20-crio.conf
+        mode: "0644"
+      notify: reload crio
+
+    - name: Wait for handlers
+      ansible.builtin.meta: flush_handlers
 
     - name: Launch services
       ansible.builtin.systemd_service:
@@ -379,6 +391,12 @@
       register: cluster_bootstrap_sysctl
       changed_when: cluster_bootstrap_sysctl.rc != 0
       listen: sysctl reconfig
+
+    - name: Reload CRIO
+      ansible.builtin.command: systemctl reload crio
+      register: systemctl_reload_crio
+      changed_when: systemctl_reload_crio.rc != 0
+      listen: reload crio
 
     - name: Reset cluster
       ansible.builtin.shell:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -213,6 +213,7 @@
         - public.ecr.aws/docker/library/redis:7.4.1-alpine
         - quay.io/tigera/operator:v1.32.7
         - docker.io/calico/ctl:v3.27.3
+        - docker.io/haproxy:2.1.4
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -51,39 +51,48 @@
       ansible.builtin.debug:
         msg: "Please install the CA certificate, which you can find here: {{ ownca_crt.filename | realpath }}"
 
-- name: Create Lima VM
+- name: Create Lima VMs
   tags: compute
   hosts: localhost
   vars_files:
     - common_vars.yaml
   tasks:
     - name: Create Lima config directory
+      loop: "{{ virtual_machine | dict2items }}"
       ansible.builtin.file:
-        path: "~/.lima/{{ virtual_machine.name }}"
+        path: "~/.lima/{{ item.key }}"
         state: directory
-      register: virtual_machine_config_dir
 
     - name: Render virtual machine configuration
+      loop: "{{ virtual_machine | dict2items }}"
       ansible.builtin.template:
-        src: templates/lima.yaml.j2
-        dest: "{{ virtual_machine_config_dir.path }}/lima.yaml"
-      register: virtual_machine_config
-      notify: restart vm
+        src: templates/{{ item.key }}-lima.yaml.j2
+        dest: "~/.lima/{{ item.key }}/lima.yaml"
+      notify: restart vm {{ item.key }}
+      vars:
+        vm: "{{ item.value }}"
+        name: "{{ item.key }}"
 
     - name: Wait for handlers
       ansible.builtin.meta: flush_handlers
 
     - name: Start virtual machine
+      loop: "{{ virtual_machine | dict2items }}"
       ansible.builtin.command:
-        cmd: limactl start --name {{ virtual_machine.name }} --tty=false
-        creates: "{{ virtual_machine_config_dir.path }}/*.pid"
+        cmd: limactl start --name {{ item.key }} --tty=false
+        creates: "~/.lima/{{ item.key }}/*.pid"
 
   handlers:
-    - name: Stop virtual machine
+    - name: Stop virtual machine (k8s)
       ansible.builtin.command:
-        cmd: limactl stop {{ virtual_machine.name }} --force
-        removes: "{{ virtual_machine_config_dir.path }}/*.pid"
-      listen: restart vm
+        cmd: limactl stop k8s --force
+        removes: "~/lima/k8s/*.pid"
+      listen: restart vm k8s
+    - name: Stop virtual machine (docker)
+      ansible.builtin.command:
+        cmd: limactl stop docker --force
+        removes: "~/lima/docker/*.pid"
+      listen: restart vm docker
 
 - name: Install Kubernetes
   tags: kubeadm
@@ -355,7 +364,7 @@
               restart: always
               image: registry:2.8
               ports:
-               - "{{ registry.port }}:443"
+                - "{{ registry.port }}:443"
               volumes:
                 - "{{ outputs_dir }}/registry:/var/lib/registry"
                 - "{{ outputs_dir }}/certs:/certs"

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -326,6 +326,17 @@
         provider: ownca
       register: registry_crt
 
+    - name: Modify /etc/hosts on Kubernetes node
+      delegate_to: k8s
+      become: true
+      vars:
+        ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') + '/.lima/' + virtual_machine.name + '/ssh.config' }}"
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        regex: '([\da-fA-F:.]+)\s+host.lima.internal'
+        line: '\1 host.lima.internal {{ registry.hosts | join(" ") }}'
+        backrefs: true
+
 - name: Deploy apps in Kubernetes
   tags: apps
   hosts: localhost

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -375,9 +375,9 @@
                 REGISTRY_HTTP_ADDR: "0.0.0.0:443"
                 REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
                 REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
-                REGISTRY_AUTH: "{{ (registry.username is defined and registry.password is defined) | ternary('htpasswd', '') }}"
-                REGISTRY_AUTH_HTPASSWD_REALM: "registry"
-                REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
+                # REGISTRY_AUTH: htpasswd
+                # REGISTRY_AUTH_HTPASSWD_REALM: "registry"
+                # REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
         wait: true
 
 - name: Deploy apps in Kubernetes

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -187,6 +187,12 @@
                 # REGISTRY_AUTH: htpasswd
                 # REGISTRY_AUTH_HTPASSWD_REALM: "registry"
                 # REGISTRY_AUTH_HTPASSWD_PATH: "/auth/htpasswd"
+              healthcheck:
+                test: nc -z localhost 443
+                interval: 10s
+                timeout: 5s
+                retries: 3
+                start_period: 0s
         wait: true
 
     - name: Push Images

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,3 +1,5 @@
 ansible==9.5.1
 ansible-lint
 kubernetes==29.0.0
+passlib==1.7.4
+bcrypt==4.3.0

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,0 +1,6 @@
+---
+collections:
+  # Install a collection from Ansible Galaxy.
+  - name: community.docker
+    version: "==4.5.2"
+    source: https://galaxy.ansible.com

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,6 +1,8 @@
 ---
 collections:
-  # Install a collection from Ansible Galaxy.
   - name: community.docker
     version: "==4.5.2"
+    source: https://galaxy.ansible.com
+  - name: community.general
+    version: "==10.5.0"
     source: https://galaxy.ansible.com

--- a/ansible/templates/docker-lima.yaml.j2
+++ b/ansible/templates/docker-lima.yaml.j2
@@ -1,0 +1,95 @@
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release-20241004/ubuntu-24.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+    digest: "sha256:fad101d50b06b26590cf30542349f9e9d3041ad7929e3bc3531c81ec27f2c788"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release-20241004/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+    digest: "sha256:e380b683b0c497d2a87af8a5dbe94c42eb54548fa976167f307ed8cf3944ec57"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+  - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+
+vmType: vz
+rosetta:
+  enabled: true
+  binfmt: true
+
+cpus: {{ vm.cpus }}
+memory: {{ vm.memory }}
+disk: {{ vm.disk }}
+
+containerd:
+  system: false
+  user: false
+
+mountInotify: true
+mountType: virtiofs
+mounts:
+  - location: "~"
+    mountPoint: /mnt/user
+  - location: "/tmp/lima"
+    writable: true
+
+provision:
+  - mode: system
+    # This script defines the host.docker.internal hostname when hostResolver is disabled.
+    # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
+    # Names defined in /etc/hosts inside the VM are not resolved inside containers when
+    # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
+    script: |
+      #!/bin/sh
+      sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
+  - # Remove the "lima-" prefix in the hostnames
+    mode: system
+    script: hostnamectl set-hostname {{ name }}
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      command -v docker >/dev/null 2>&1 && exit 0
+      if [ ! -e /etc/systemd/system/docker.socket.d/override.conf ]; then
+        mkdir -p /etc/systemd/system/docker.socket.d
+        # Alternatively we could just add the user to the "docker" group, but that requires restarting the user session
+        cat <<-EOF >/etc/systemd/system/docker.socket.d/override.conf
+        [Socket]
+        {%- raw %}
+        SocketUser={{.User}}
+        {%- endraw %}
+      EOF
+      fi
+      export DEBIAN_FRONTEND=noninteractive
+      curl -fsSL https://get.docker.com | sh
+
+probes:
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+        echo >&2 "docker is not installed yet"
+        exit 1
+      fi
+      if ! timeout 30s bash -c "until pgrep dockerd; do sleep 3; done"; then
+        echo >&2 "dockerd is not running"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log" in the guest
+
+hostResolver:
+  # hostResolver.hosts requires lima 0.8.3 or later. Names defined here will also
+  # resolve inside containers, and not just inside the VM itself.
+  hosts:
+    host.docker.internal: host.lima.internal
+
+{%- raw %}
+portForwards:
+- guestSocket: "/var/run/docker.sock"
+  hostSocket: "{{.Dir}}/sock/docker.sock"
+message: |
+  To run `docker` on the host (assumes docker-cli is installed), run the following commands:
+  ------
+  docker context create lima-{{.Name}} --docker "host=unix://{{.Dir}}/sock/docker.sock"
+  docker context use lima-{{.Name}}
+  docker run hello-world
+  ------
+{%- endraw %}

--- a/ansible/templates/etc/kubernetes/kubeadm.conf.j2
+++ b/ansible/templates/etc/kubernetes/kubeadm.conf.j2
@@ -30,11 +30,12 @@ apiServer:
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ kubernetes_cluster_name }}
 controllerManager: {}
-dns: {}
+dns:
+  imageRepository: registry:{{ registry.port }}/registry.k8s.io/coredns
 etcd:
   local:
     dataDir: /var/lib/etcd
-imageRepository: registry.k8s.io
+imageRepository: registry:{{ registry.port }}/registry.k8s.io
 networking:
   dnsDomain: cluster.local
   serviceSubnet: {{ kubernetes_service_cidr }}

--- a/ansible/templates/k8s-lima.yaml.j2
+++ b/ansible/templates/k8s-lima.yaml.j2
@@ -15,9 +15,9 @@ rosetta:
   enabled: true
   binfmt: true
 
-cpus: {{ virtual_machine.cpus }}
-memory: {{ virtual_machine.memory }}
-disk: {{ virtual_machine.disk }}
+cpus: {{ vm.cpus }}
+memory: {{ vm.memory }}
+disk: {{ vm.disk }}
 
 containerd:
   user: false
@@ -34,7 +34,7 @@ mounts:
 provision:
   - # Remove the "lima-" prefix in the hostnames
     mode: system
-    script: hostnamectl set-hostname {{ virtual_machine.name }}
+    script: hostnamectl set-hostname {{ name }}
 
 hostResolver:
   enabled: false

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
+set -euo pipefail
+
 PROJECT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 VENV_DIR="${PROJECT_DIR}/.venv"
 ANSIBLE_DIR="${PROJECT_DIR}/ansible"
 
 if [ ! -d "$VENV_DIR" ]; then
     python3 -m venv "$VENV_DIR"
-    "$VENV_DIR"/bin/pip install -r "$ANSIBLE_DIR"/requirements.txt
 fi
 
 source "$VENV_DIR"/bin/activate
+pip install -r "$ANSIBLE_DIR"/requirements.txt
+ansible-galaxy collection install -r "$ANSIBLE_DIR"/requirements.yaml
 ansible-playbook "$ANSIBLE_DIR"/playbook.yaml -i "$ANSIBLE_DIR"/inventory.ini "$@"

--- a/kubernetes/helm-chart-apps/argo-cd/values.yaml
+++ b/kubernetes/helm-chart-apps/argo-cd/values.yaml
@@ -1,5 +1,7 @@
 global:
   domain: argocd.localhost
+  image:
+    repository: registry:5001/quay.io/argoproj/argocd
 
 server:
   ingress:
@@ -21,3 +23,7 @@ configs:
 
   params:
     server.insecure: true
+
+redis:
+  image:
+    repository: registry:5001/public.ecr.aws/docker/library/redis

--- a/kubernetes/helm-chart-apps/cert-manager/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/cert-manager/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 1.16.1
 helmChartURL: https://charts.jetstack.io
 namespace: cert-manager
 syncWave: -99
-valuesRevision: HEAD
+valuesRevision: custom-registry

--- a/kubernetes/helm-chart-apps/jenkins/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/jenkins/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 5.8.17
 helmChartURL: https://charts.jenkins.io
 namespace: jenkins
 syncWave: 0
-valuesRevision: HEAD
+valuesRevision: custom-registry

--- a/kubernetes/helm-chart-apps/local-path-provisioner/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/local-path-provisioner/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 0.0.31
 helmChartURL: https://charts.containeroo.ch
 namespace: local-path-provisioner
 syncWave: -99
-valuesRevision: HEAD
+valuesRevision: custom-registry

--- a/kubernetes/helm-chart-apps/metrics-server/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 3.12.2
 helmChartURL: https://kubernetes-sigs.github.io/metrics-server/
 namespace: metrics-server
 syncWave: -99
-valuesRevision: HEAD
+valuesRevision: custom-registry

--- a/kubernetes/helm-chart-apps/nginx-ingress/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/nginx-ingress/appset-config.yaml
@@ -4,4 +4,4 @@ helmChartVersion: 1.2.0
 helmChartURL: ghcr.io/nginxinc/charts
 namespace: nginx-ingress
 syncWave: -99
-valuesRevision: HEAD
+valuesRevision: custom-registry

--- a/kubernetes/helm-chart-apps/tigera-operator/values.yaml
+++ b/kubernetes/helm-chart-apps/tigera-operator/values.yaml
@@ -4,3 +4,6 @@ tigeraOperator:
 
 calicoctl:
   image: registry:5001/docker.io/calico/ctl
+
+installation:
+  registry: registry:5001/docker.io/

--- a/kubernetes/helm-chart-apps/tigera-operator/values.yaml
+++ b/kubernetes/helm-chart-apps/tigera-operator/values.yaml
@@ -1,0 +1,6 @@
+tigeraOperator:
+  image: quay.io/tigera/operator
+  registry: registry:5001
+
+calicoctl:
+  image: registry:5001/docker.io/calico/ctl


### PR DESCRIPTION
- **TLS certs for the registry**
- **Ensure that K8s can resolve the registry IP**
- **Use latest docker collection with fixes for compose**
- **Registry CSR must be for a serving TLS**
- **Serve the registry securely**
- **Use port 5001 because 5000 is used by Airplay in macOS**
- **Provision VM for docker**
- **Fix ssh_common_args after refactoring**
- **Disable auth**
- **Comment-out env vars for registry auth to disable**
- **Drop registry DNS name because it resolves to quay**
- **Just use plain registry for the SAN**
- **registry should be a default SAN**
- **Create registry before kubernetes**
- **Install additional requirements: docker and skopeo**
- **Push kubeadm images**
- **Enlarge k8s eph storage**
- **Add healthcheck to the registry docker compose service**
- **Deploy cluster with prepulled images**
- **Redeploy ArgoCD images with private registry**
- **Move tigera-operator to private registry**
- **Move haproxy to private registry**
- **Moved Calico to private registry**
- **TODO: Pin charts to private registry**
- **Document private registry**
