### PR TITLE
Move ArgoCD-deployed apps to private registry

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -230,6 +230,8 @@
         - docker.io/kiwigrid/k8s-sidecar:1.30.1
         - docker.io/rancher/local-path-provisioner:v0.0.30
         - registry.k8s.io/metrics-server/metrics-server:v0.7.2
+        - docker.io/hashicorp/vault:1.16.1
+        - docker.io/hashicorp/vault-k8s:1.4.1
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -225,6 +225,9 @@
         - quay.io/jetstack/cert-manager-controller:v1.16.1
         - quay.io/jetstack/cert-manager-webhook:v1.16.1
         - quay.io/jetstack/cert-manager-cainjector:v1.16.1
+        - docker.io/jenkins/jenkins:2.492.1-jdk17
+        - docker.io/jenkins/inbound-agent:3307.v632ed11b_3a_c7-2
+        - docker.io/kiwigrid/k8s-sidecar:1.30.1
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -232,6 +232,7 @@
         - registry.k8s.io/metrics-server/metrics-server:v0.7.2
         - docker.io/hashicorp/vault:1.16.1
         - docker.io/hashicorp/vault-k8s:1.4.1
+        - docker.io/nginx/nginx-ingress:3.5.0
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -229,6 +229,7 @@
         - docker.io/jenkins/inbound-agent:3307.v632ed11b_3a_c7-2
         - docker.io/kiwigrid/k8s-sidecar:1.30.1
         - docker.io/rancher/local-path-provisioner:v0.0.30
+        - registry.k8s.io/metrics-server/metrics-server:v0.7.2
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -228,6 +228,7 @@
         - docker.io/jenkins/jenkins:2.492.1-jdk17
         - docker.io/jenkins/inbound-agent:3307.v632ed11b_3a_c7-2
         - docker.io/kiwigrid/k8s-sidecar:1.30.1
+        - docker.io/rancher/local-path-provisioner:v0.0.30
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -222,6 +222,9 @@
         - docker.io/calico/node-driver-registrar:v3.27.3
         - docker.io/calico/pod2daemon-flexvol:v3.27.3
         - docker.io/haproxy:2.1.4
+        - quay.io/jetstack/cert-manager-controller:v1.16.1
+        - quay.io/jetstack/cert-manager-webhook:v1.16.1
+        - quay.io/jetstack/cert-manager-cainjector:v1.16.1
 
       register: skopeo_copy
       changed_when: skopeo_copy.rc != 0

--- a/kubernetes/helm-chart-apps/cert-manager/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/cert-manager/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 1.16.1
 helmChartURL: https://charts.jetstack.io
 namespace: cert-manager
 syncWave: -99
-valuesRevision: custom-registry
+valuesRevision: HEAD

--- a/kubernetes/helm-chart-apps/cert-manager/values.yaml
+++ b/kubernetes/helm-chart-apps/cert-manager/values.yaml
@@ -9,3 +9,12 @@ extraObjects:
     spec:
       ca:
         secretName: own-ca
+
+image:
+  repository: registry:5001/quay.io/jetstack/cert-manager-controller
+webhook:
+  image:
+    repository: registry:5001/quay.io/jetstack/cert-manager-webhook
+cainjector:
+  image:
+    repository: registry:5001/quay.io/jetstack/cert-manager-cainjector

--- a/kubernetes/helm-chart-apps/jenkins/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/jenkins/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 5.8.17
 helmChartURL: https://charts.jenkins.io
 namespace: jenkins
 syncWave: 0
-valuesRevision: custom-registry
+valuesRevision: HEAD

--- a/kubernetes/helm-chart-apps/jenkins/values.yaml
+++ b/kubernetes/helm-chart-apps/jenkins/values.yaml
@@ -13,3 +13,15 @@ controller:
       - secretName: jenkins-tls
         hosts:
           - jenkins.localhost
+
+  image:
+    registry: registry:5001/docker.io
+
+  sidecars:
+    configAutoReload:
+      image:
+        registry: registry:5001/docker.io
+
+agent:
+  image:
+    repository: "registry:5001/docker.io/jenkins/inbound-agent"

--- a/kubernetes/helm-chart-apps/local-path-provisioner/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/local-path-provisioner/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 0.0.31
 helmChartURL: https://charts.containeroo.ch
 namespace: local-path-provisioner
 syncWave: -99
-valuesRevision: custom-registry
+valuesRevision: HEAD

--- a/kubernetes/helm-chart-apps/local-path-provisioner/values.yaml
+++ b/kubernetes/helm-chart-apps/local-path-provisioner/values.yaml
@@ -5,3 +5,6 @@ nodePathMap:
   - node: DEFAULT_PATH_FOR_NON_LISTED_NODES
     paths:
       - /mnt/data
+
+image:
+  repository: registry:5001/docker.io/rancher/local-path-provisioner

--- a/kubernetes/helm-chart-apps/metrics-server/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/appset-config.yaml
@@ -3,4 +3,4 @@ helmChartVersion: 3.12.2
 helmChartURL: https://kubernetes-sigs.github.io/metrics-server/
 namespace: metrics-server
 syncWave: -99
-valuesRevision: custom-registry
+valuesRevision: HEAD

--- a/kubernetes/helm-chart-apps/metrics-server/values.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/values.yaml
@@ -3,4 +3,4 @@ args:
   - --kubelet-insecure-tls
 
 image:
-  repository: registry:5001/registry.k8s.io/metrics-server
+  repository: registry:5001/registry.k8s.io/metrics-server/metrics-server

--- a/kubernetes/helm-chart-apps/metrics-server/values.yaml
+++ b/kubernetes/helm-chart-apps/metrics-server/values.yaml
@@ -1,3 +1,6 @@
 args:
   # See https://github.com/kubernetes/kubeadm/issues/1223#issuecomment-549416594
   - --kubelet-insecure-tls
+
+image:
+  repository: registry:5001/registry.k8s.io/metrics-server

--- a/kubernetes/helm-chart-apps/nginx-ingress/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/nginx-ingress/appset-config.yaml
@@ -4,4 +4,4 @@ helmChartVersion: 1.2.0
 helmChartURL: ghcr.io/nginxinc/charts
 namespace: nginx-ingress
 syncWave: -99
-valuesRevision: custom-registry
+valuesRevision: HEAD

--- a/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
+++ b/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
@@ -18,4 +18,4 @@ controller:
     report-ingress-status:
 
   image:
-    repository: registry:5001/docker.io/nginx
+    repository: registry:5001/docker.io/nginx/nginx-ingress

--- a/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
+++ b/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
@@ -6,6 +6,7 @@ controller:
       set-real-ip-from: "127.0.0.1"
       real-ip-header: "X-Forwarded-For"
       client-max-body-size: "0"
+
   service:
     type: NodePort
     httpPort:
@@ -15,3 +16,6 @@ controller:
 
   extraArgs:
     report-ingress-status:
+
+  image:
+    repository: registry:5001/docker.io/nginx

--- a/kubernetes/helm-chart-apps/vault/values.yaml
+++ b/kubernetes/helm-chart-apps/vault/values.yaml
@@ -20,3 +20,12 @@ server:
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
+
+  image:
+    repository: registry:5001/docker.io/hashicorp/vault
+
+injector:
+  image:
+    repository: registry:5001/docker.io/hashicorp/vault-k8s
+  agentImage:
+    repository: registry:5001/docker.io/hashicorp/vault


### PR DESCRIPTION
- **TLS certs for the registry**
- **Ensure that K8s can resolve the registry IP**
- **Use latest docker collection with fixes for compose**
- **Registry CSR must be for a serving TLS**
- **Serve the registry securely**
- **Use port 5001 because 5000 is used by Airplay in macOS**
- **Provision VM for docker**
- **Fix ssh_common_args after refactoring**
- **Disable auth**
- **Comment-out env vars for registry auth to disable**
- **Drop registry DNS name because it resolves to quay**
- **Just use plain registry for the SAN**
- **registry should be a default SAN**
- **Create registry before kubernetes**
- **Install additional requirements: docker and skopeo**
- **Push kubeadm images**
- **Enlarge k8s eph storage**
- **Add healthcheck to the registry docker compose service**
- **Deploy cluster with prepulled images**
- **Redeploy ArgoCD images with private registry**
- **Move tigera-operator to private registry**
- **Move haproxy to private registry**
- **Moved Calico to private registry**
- **TODO: Pin charts to private registry**
- **Document private registry**
- **Moved certmanager to private registry**
- **Moved jenkins to private registry**
- **Move local-path-provisioner to private registry**
- **Move metrics-server to private registry**
- **Fix metrics-server image repo**
- **Move vault to private registry**
- **Migrate nginx to private registry**
- **Fix ingress repo path for nginx**
- **Revert "TODO: Pin charts to private registry"**
