### PR TITLE
Rename nginx ingress class

### DIFF
--- a/kubernetes/helm-chart-apps/argo-cd/values.yaml
+++ b/kubernetes/helm-chart-apps/argo-cd/values.yaml
@@ -6,7 +6,7 @@ global:
 server:
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: nginxinc
     annotations:
       cert-manager.io/cluster-issuer: "ingress-cert-issuer"
     tls: true

--- a/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
+++ b/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
@@ -19,3 +19,8 @@ controller:
 
   image:
     repository: registry:5001/docker.io/nginx/nginx-ingress
+
+  ingressClass:
+    name: nginxinc
+    create: true
+    setAsDefaultIngress: false

--- a/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
+++ b/kubernetes/helm-chart-apps/nginx-ingress/values.yaml
@@ -23,4 +23,4 @@ controller:
   ingressClass:
     name: nginxinc
     create: true
-    setAsDefaultIngress: false
+    setAsDefaultIngress: true

--- a/kubernetes/helm-chart-apps/prometheus/values.yaml
+++ b/kubernetes/helm-chart-apps/prometheus/values.yaml
@@ -8,7 +8,7 @@ server:
     repository: registry:5001/quay.io/prometheus/prometheus
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: nginxinc
     annotations:
       cert-manager.io/cluster-issuer: "ingress-cert-issuer"
     hosts:

--- a/kubernetes/helm-chart-apps/vault/values.yaml
+++ b/kubernetes/helm-chart-apps/vault/values.yaml
@@ -6,7 +6,7 @@ server:
     enabled: true
     annotations:
       cert-manager.io/cluster-issuer: ingress-cert-issuer
-    ingressClassName: nginx
+    ingressClassName: nginxinc
     hosts:
       - host: vault.localhost
         path: []


### PR DESCRIPTION
This allows me to use a similarly named ingress-nginx from the Kube authors.